### PR TITLE
Fix CTRL-D showing connection error instead of graceful session end

### DIFF
--- a/macSCP/Data/Terminal/TerminalSession.swift
+++ b/macSCP/Data/Terminal/TerminalSession.swift
@@ -16,6 +16,7 @@ actor TerminalSession: TerminalSessionProtocol {
     private var client: SSHClient?
     private var eventLoopGroup: MultiThreadedEventLoopGroup?
     private(set) var isConnected = false
+    private(set) var sessionEndedGracefully = false
 
     // PTY state
     private var ptyTask: Task<Void, Error>?
@@ -53,6 +54,7 @@ actor TerminalSession: TerminalSessionProtocol {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         eventLoopGroup = group
         currentSize = terminalSize
+        sessionEndedGracefully = false
 
         do {
             let normalizedHost = (host.lowercased() == "localhost") ? "127.0.0.1" : host
@@ -102,6 +104,7 @@ actor TerminalSession: TerminalSessionProtocol {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         eventLoopGroup = group
         currentSize = terminalSize
+        sessionEndedGracefully = false
 
         do {
             let normalizedHost = (host.lowercased() == "localhost") ? "127.0.0.1" : host
@@ -199,6 +202,12 @@ actor TerminalSession: TerminalSessionProtocol {
                         }
                     }
                 }
+
+                // PTY stream ended normally (e.g. user exited shell with CTRL-D/exit)
+                if !Task.isCancelled {
+                    logInfo("Terminal session ended gracefully", category: .network)
+                    await self.handleGracefulSessionEnd()
+                }
             } catch {
                 // Only log as error if not cancelled (intentional disconnect)
                 if !Task.isCancelled {
@@ -215,6 +224,12 @@ actor TerminalSession: TerminalSessionProtocol {
 
     private func sendOutput(_ data: Data) {
         outputContinuation?.yield(data)
+    }
+
+    private func handleGracefulSessionEnd() {
+        isConnected = false
+        sessionEndedGracefully = true
+        outputContinuation?.finish()
     }
 
     private func handlePTYError(_ error: Error) {

--- a/macSCP/Data/Terminal/TerminalSessionProtocol.swift
+++ b/macSCP/Data/Terminal/TerminalSessionProtocol.swift
@@ -69,6 +69,10 @@ protocol TerminalSessionProtocol: Sendable {
     ///   - rows: New height in characters
     func resize(columns: Int, rows: Int) async throws
 
+    /// Whether the session ended gracefully (e.g. user exited shell with CTRL-D)
+    /// rather than due to a network error or unexpected disconnection
+    var sessionEndedGracefully: Bool { get async }
+
     /// Disconnect from the server
     func disconnect() async
 }

--- a/macSCP/Features/Terminal/TerminalView.swift
+++ b/macSCP/Features/Terminal/TerminalView.swift
@@ -15,6 +15,7 @@ struct TerminalContentView: View {
     @Bindable var viewModel: TerminalViewModel
 
     @State private var showConnectionLostBanner = false
+    @State private var showSessionEndedBanner = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -57,14 +58,23 @@ struct TerminalContentView: View {
             if case .connected = oldState, case .error = newState {
                 withAnimation(.easeInOut(duration: 0.25)) {
                     showConnectionLostBanner = true
+                    showSessionEndedBanner = false
+                }
+            } else if case .connected = oldState, case .disconnected = newState {
+                // Graceful session end (e.g. CTRL-D / exit)
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    showSessionEndedBanner = true
+                    showConnectionLostBanner = false
                 }
             } else if case .connected = newState {
                 withAnimation(.easeInOut(duration: 0.25)) {
                     showConnectionLostBanner = false
+                    showSessionEndedBanner = false
                 }
             } else if case .connecting = newState {
                 withAnimation(.easeInOut(duration: 0.25)) {
                     showConnectionLostBanner = false
+                    showSessionEndedBanner = false
                 }
             }
         }
@@ -86,7 +96,7 @@ struct TerminalContentView: View {
             Spacer()
 
             // Terminal dimensions
-            if viewModel.isConnected || showConnectionLostBanner {
+            if viewModel.isConnected || showConnectionLostBanner || showSessionEndedBanner {
                 Text(viewModel.terminalSizeText)
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(.tertiary)
@@ -101,20 +111,31 @@ struct TerminalContentView: View {
     private var terminalContent: some View {
         switch viewModel.state {
         case .disconnected:
-            ContentUnavailableView {
-                Label("Disconnected", systemImage: "terminal")
-            } description: {
-                Text("The terminal session is not connected.")
-            } actions: {
-                Button {
-                    Task {
-                        await viewModel.reconnect()
-                    }
-                } label: {
-                    Text("Connect")
+            if showSessionEndedBanner {
+                // Session ended gracefully — preserve terminal content with overlay
+                ZStack {
+                    SwiftTermView(viewModel: viewModel)
+                        .allowsHitTesting(false)
+                        .opacity(0.4)
+
+                    sessionEndedBanner
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.regular)
+            } else {
+                ContentUnavailableView {
+                    Label("Disconnected", systemImage: "terminal")
+                } description: {
+                    Text("The terminal session is not connected.")
+                } actions: {
+                    Button {
+                        Task {
+                            await viewModel.reconnect()
+                        }
+                    } label: {
+                        Text("Connect")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                }
             }
 
         case .connecting:
@@ -153,6 +174,40 @@ struct TerminalContentView: View {
                     .controlSize(.regular)
                 }
             }
+        }
+    }
+
+    private var sessionEndedBanner: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "terminal")
+                .font(.system(size: 28, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            Text("Session Ended")
+                .font(.system(size: 15, weight: .semibold))
+
+            Text("The remote shell has exited.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button {
+                Task {
+                    showSessionEndedBanner = false
+                    await viewModel.reconnect()
+                }
+            } label: {
+                Label("Reconnect", systemImage: "arrow.clockwise")
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+        }
+        .padding(32)
+        .background {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .shadow(color: .black.opacity(0.1), radius: 20, x: 0, y: 5)
         }
     }
 
@@ -198,7 +253,9 @@ struct TerminalContentView: View {
             return .green
         case .connecting:
             return .orange
-        case .disconnected, .error:
+        case .disconnected:
+            return showSessionEndedBanner ? .gray : .red
+        case .error:
             return .red
         }
     }
@@ -211,7 +268,7 @@ struct TerminalContentView: View {
         case .connecting:
             return "Connecting..."
         case .disconnected:
-            return "Disconnected"
+            return showSessionEndedBanner ? "Session Ended" : "Disconnected"
         case .error:
             return "Connection Error"
         }
@@ -225,7 +282,7 @@ struct TerminalContentView: View {
         case .connecting:
             return "Connecting..."
         case .disconnected:
-            return "Disconnected"
+            return showSessionEndedBanner ? "Session Ended" : "Disconnected"
         case .error:
             return "Connection Lost"
         }

--- a/macSCP/Features/Terminal/TerminalViewModel.swift
+++ b/macSCP/Features/Terminal/TerminalViewModel.swift
@@ -186,11 +186,16 @@ final class TerminalViewModel {
                 }
             }
 
-            // Stream ended - connection may have been lost
+            // Stream ended - check if session ended gracefully or unexpectedly
+            let graceful = await self.session.sessionEndedGracefully
             await MainActor.run {
                 if self.isConnected {
                     self.isConnected = false
-                    self.state = .error(.terminalConnectionLost)
+                    if graceful {
+                        self.state = .disconnected
+                    } else {
+                        self.state = .error(.terminalConnectionLost)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Distinguishes graceful shell exit (CTRL-D/`exit`) from unexpected connection loss
- Adds `sessionEndedGracefully` flag to `TerminalSession` that is set when PTY stream ends without error
- ViewModel transitions to `.disconnected` instead of `.error(.terminalConnectionLost)` for graceful ends
- Shows "Session Ended" banner (with gray status dot) instead of "Connection Lost" error banner

## Changes

| File | Change |
|------|--------|
| `TerminalSession.swift` | Added `sessionEndedGracefully` flag, `handleGracefulSessionEnd()` method, reset on reconnect |
| `TerminalSessionProtocol.swift` | Exposed `sessionEndedGracefully` property |
| `TerminalViewModel.swift` | Check graceful flag to choose `.disconnected` vs `.error` |
| `TerminalView.swift` | Added "Session Ended" banner UI, gray status color, updated status text |

## Test plan

- [ ] Connect to an SSH server and press CTRL-D — should show "Session Ended" banner, not "Connection Lost"
- [ ] Type `exit` in the shell — same graceful behavior
- [ ] Kill network mid-session — should still show "Connection Lost" error banner
- [ ] Click "Reconnect" from session ended banner — should reconnect successfully
- [ ] Verify terminal output is preserved (dimmed) behind the session ended banner

Fixes https://github.com/macnev2013/macSCP/issues/14
