### PR TITLE
Fix passwordless key-based auth prompting for mandatory password

### DIFF
--- a/macSCP/Features/Connections/ConnectionListViewModel.swift
+++ b/macSCP/Features/Connections/ConnectionListViewModel.swift
@@ -319,6 +319,10 @@ final class ConnectionListViewModel {
                 if let savedPassword = keychainService.getPassword(for: connection.id) {
                     logInfo("Found saved password, opening browser", category: .ui)
                     openFileBrowser(for: connection, password: savedPassword)
+                } else if connection.authMethod == .privateKey {
+                    // Key-based auth doesn't require a password — connect directly
+                    logInfo("Private key auth, connecting without password", category: .ui)
+                    openFileBrowser(for: connection, password: "")
                 } else {
                     logInfo("No saved password, showing prompt", category: .ui)
                     isShowingPasswordPrompt = true
@@ -415,6 +419,10 @@ final class ConnectionListViewModel {
             // Check for saved password
             if let savedPassword = keychainService.getPassword(for: connection.id) {
                 openTerminal(for: connection, password: savedPassword)
+            } else if connection.authMethod == .privateKey {
+                // Key-based auth doesn't require a password — connect directly
+                logInfo("Private key auth, opening terminal without password", category: .ui)
+                openTerminal(for: connection, password: "")
             } else {
                 // Need to prompt for password
                 isShowingPasswordPrompt = true


### PR DESCRIPTION
## Summary

- Fixes key-based SSH auth (e.g. OCI instances) being blocked by an unnecessary password prompt
- `connectToServer()` and `requestTerminal()` now check `connection.authMethod` before showing the password prompt
- For `.privateKey` auth with no saved passphrase, connects directly with empty string (downstream code already converts this to `nil`)

## Changes

| File | Change |
|------|--------|
| `ConnectionListViewModel.swift` | Added `authMethod == .privateKey` check in both `connectToServer()` and `requestTerminal()` to skip password prompt |

## Test plan

- [ ] Create a connection with private key auth (no passphrase) — should connect without password prompt
- [ ] Create a connection with private key auth and a saved passphrase — should use saved passphrase
- [ ] Create a connection with password auth — should still prompt for password when not saved
- [ ] Verify OCI instance connection works end-to-end with key-only auth

Fixes https://github.com/macnev2013/macSCP/issues/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)