### PR TITLE
Add Homebrew Cask formula

### DIFF
--- a/Casks/macscp.rb
+++ b/Casks/macscp.rb
@@ -1,0 +1,24 @@
+cask "macscp" do
+  version "0.2.6"
+  sha256 "9bc8b75e3325c18190bb5902c6a7bae04fe9009d8eaf14c68420be09cbdcf1af"
+
+  url "https://github.com/macnev2013/macSCP/releases/download/v#{version}/macSCP-#{version}.dmg"
+  name "macSCP"
+  desc "Native client for SFTP, S3, and SSH terminal"
+  homepage "https://www.macscp.co/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sequoia"
+
+  app "macSCP.app"
+
+  zap trash: [
+    "~/Library/Caches/com.macscp.macSCP",
+    "~/Library/Preferences/com.macscp.macSCP.plist",
+    "~/Library/Saved Application State/com.macscp.macSCP.savedState",
+  ]
+end


### PR DESCRIPTION
## Summary

- Adds a Homebrew Cask formula (`Casks/macscp.rb`) for macSCP v0.2.6
- Enables installation via `brew install --cask macnev2013/macscp/macscp`
- Formula includes livecheck for automatic version detection, proper sha256 verification, and zap stanza for clean uninstall

## Test plan

- [x] `brew style Casks/macscp.rb` passes with no offenses
- [x] `brew install --cask macnev2013/macscp/macscp` installs successfully
- [x] App appears in /Applications/macSCP.app and launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)